### PR TITLE
Adding initial version of travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,42 @@
+
+language: cpp
+
+env:
+  global:
+  - ExternalData_OBJECT_STORES="${HOME}/.ExternalData"
+  - ITK_REPOSITORY="${ExternalData_OBJECT_STORES}/ITK.git"
+  - ITK_MODULE=ModuleTemplate
+  - ITK_TAG=master
+  - PROJ_SRC="${TRAVIS_BUILD_DIR}"
+  - CMAKE_DOWNLOAD_FILE: cmake-3.6.0-Linux-x86_64.sh
+
+cache:
+  directories:
+    - ${ExternalData_OBJECT_STORES}
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: required
+    - os: osx
+      osx_image: xcode7.3
+    - os: osx
+      osx_image: xcode6.4
+
+
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install ninja $( command -V cmake &>2 /dev/null || echo "cmake" ); fi
+
+before_script:
+   - cmake --version
+   - ( cd ${ExternalData_OBJECT_STORES} && if [[ ! -e ${ITK_REPOSITORY} ]]; then git clone --bare https://ITK.org/ITK.git; fi && cd ${ITK_REPOSITORY} && git fetch origin )
+   - cd ${PROJ_SRC} && git clone ${ITK_REPOSITORY} -b "${ITK_TAG}" && ( cd ITK/Modules/Remote && ln -s ${PROJ_SRC} module )
+   - mkdir -p bld
+
+script:
+   - cd bld
+   - cmake "-DMAKE_CXX_FLAGS=-std=c++11" -D "Module_${ITK_MODULE}:BOOL=ON" -D  BUILD_TESTING:BOOL=ON "${PROJ_SRC}/ITK"
+   - make -j 2 "${ITK_MODULE}-all"
+   - ctest -L "${ITK_MODULE}"

--- a/test/itkLogNormalDistributionImageSourceTest.cxx
+++ b/test/itkLogNormalDistributionImageSourceTest.cxx
@@ -39,7 +39,7 @@ int itkLogNormalDistributionImageSourceTest( int argc, char * argv[] )
   typedef itk::LogNormalDistributionImageSource< ImageType > DistributionSourceType;
   DistributionSourceType::Pointer distributionSource = DistributionSourceType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS( distributionSource, LogNormalDistributionImageSource );
+  EXERCISE_BASIC_OBJECT_METHODS( distributionSource, LogNormalDistributionImageSource, GenerateImageSource );
 
   distributionSource->SetSeed( 23334 );
   TEST_SET_GET_VALUE( 23334, distributionSource->GetSeed() );

--- a/test/itkMinimalStandardRandomVariateGeneratorTest.cxx
+++ b/test/itkMinimalStandardRandomVariateGeneratorTest.cxx
@@ -27,8 +27,8 @@ int itkMinimalStandardRandomVariateGeneratorTest( int, char * [] )
 {
   typedef itk::Statistics::MinimalStandardRandomVariateGenerator GeneratorType;
   GeneratorType::Pointer generator = GeneratorType::New();
-  
-  EXERCISE_BASIC_OBJECT_METHODS( generator, MinimalStandardRandomVariateGenerator );
+
+  EXERCISE_BASIC_OBJECT_METHODS( generator, MinimalStandardRandomVariateGenerator,  RandomVariateGeneratorBase );
 
   generator->Initialize( 324 );
   TEST_EXPECT_EQUAL( 15639804, generator->GetIntegerVariate() );


### PR DESCRIPTION
Adding continuous integration reveals numerous problems with repo.

1) the use of std::random restricts the systems which can compile/test this repo. This is not good design for an example module.
2) There are compilation errors with changing macros.
